### PR TITLE
Advance opentype

### DIFF
--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayout.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayout.java
@@ -67,7 +67,7 @@ public final class AdvancedTextLayout
             String fontFile = dir + "NotoSans-Regular.ttf";
 
 
-                    AdvancedOTFParser fontParser = new AdvancedOTFParser();
+            AdvancedOTFParser fontParser = new AdvancedOTFParser();
             AdvancedOpenTypeFont otFont = fontParser.parse(fontFile);
             PDFont font = PDType0Font.load(document, otFont, true);
 

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayout.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayout.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.fontbox.ttf.OTFParser;
 import org.apache.fontbox.ttf.OpenTypeFont;
+import org.apache.fontbox.ttf.advanced.GlyphVectorAdvanced;
 import org.apache.fontbox.ttf.advanced.api.AdvancedOTFParser;
 import org.apache.fontbox.ttf.advanced.api.AdvancedOpenTypeFont;
 import org.apache.fontbox.ttf.advanced.api.GlyphVector;
@@ -58,12 +59,15 @@ public final class AdvancedTextLayout
             PDPage page = new PDPage(PDRectangle.A4);
             document.addPage(page);
 
-            String dir = "C:\\Users\\daniel\\Desktop\\fonts\\";
+            //String dir = "C:\\Users\\daniel\\Desktop\\fonts\\";
             //String fontFile = "./pdfbox/src/main/resources/org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf";
             //String fontFile = dir + "IndieFlower-Regular.ttf";
-            String fontFile = dir + "SourceSansPro-Regular.ttf";
+            //String fontFile = dir + "SourceSansPro-Regular.ttf";
+            String dir = "/home/volker/work/";
+            String fontFile = dir + "NotoSans-Regular.ttf";
 
-            AdvancedOTFParser fontParser = new AdvancedOTFParser();
+
+                    AdvancedOTFParser fontParser = new AdvancedOTFParser();
             AdvancedOpenTypeFont otFont = fontParser.parse(fontFile);
             PDFont font = PDType0Font.load(document, otFont, true);
 
@@ -76,22 +80,26 @@ public final class AdvancedTextLayout
                 stream.beginText();
                 stream.setFont(font, fontSize);
 
-                vector = otFont.createGlyphVector("PDFBox's Unicode with Embedded OpenType Font");
-                stream.showGlyphVector(vector, createMatrix(x, 200));
+                vector = otFont.createGlyphVector("PDFBox's Unicode with Embedded OpenType Font", (int)fontSize);
+                stream.setTextMatrix(createMatrix(x, 200));
+                stream.showGlyphVector(vector);
                 x = getAdvance(10, vector, fontSize);
 
-                vector = otFont.createGlyphVector("|AFTER (SIMPLE)");
-                stream.showGlyphVector(vector, createMatrix(x, 200));
+                vector = otFont.createGlyphVector("|AFTER (SIMPLE)", (int)fontSize);
+                stream.setTextMatrix(createMatrix(x, 200));
+                stream.showGlyphVector(vector);
                 x = 10;
 
                 String complex = "A̋L̦    a̋   N̂N̦B ўў 1/2";
 
-                vector = otFont.createGlyphVector(complex);
-                stream.showGlyphVector(vector, createMatrix(x, 100));
+                vector = otFont.createGlyphVector(complex, (int)fontSize);
+                stream.setTextMatrix(createMatrix(x, 100));
+                stream.showGlyphVector(vector);
                 x = getAdvance(10, vector, fontSize);
 
-                vector = otFont.createGlyphVector("|AFTER (COMPLEX)");
-                stream.showGlyphVector(vector, createMatrix(x, 100));
+                vector = otFont.createGlyphVector("|AFTER (COMPLEX)", (int)fontSize);
+                stream.setTextMatrix(createMatrix(x, 100));
+                stream.showGlyphVector(vector);
 
                 stream.setTextMatrix(Matrix.getTranslateInstance(10, 160));
                 stream.showText(complex);

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -72,7 +72,7 @@ import java.text.Bidi;
  */
 public final class AdvancedTextLayoutSequencesDin91379
 {
-    public static String sequencesDin91379 =  /*"C̨̆x"; */
+    public static String sequencesDin91379 =  "K̛"; /* +
              "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n"
             + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
             + "T̈ T̕ T̛ U̇ Z̀ Z̄ Z̆ Z̈ Z̧ a̋ c̀ c̄ c̆ c̈ c̕ c̣ c̦ c̨̆ d̂ f̀ f̄ g̀ h̄ h̦ j́ k̀ \n"
@@ -92,7 +92,8 @@ public final class AdvancedTextLayoutSequencesDin91379
         }
         String dir = args[0];
         String[] fontFileNames = new String[] {
-                "NotoSans-Regular.ttf",
+//                "NotoSans-Regular.ttf",
+                "NotoSansMono-Regular.ttf",
            /*     "LiberationSans-Regular.ttf",
                 "DejaVuSans.ttf",
                 "IBMPlexSans-Regular.ttf",
@@ -100,7 +101,7 @@ public final class AdvancedTextLayoutSequencesDin91379
 
             */
         };
-        float[] fontSizes = new float[]{20f};
+        float[] fontSizes = new float[]{16f};
 
         for (float fontSize: fontSizes) {
             for (String fontFileName : fontFileNames) {

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -28,7 +28,7 @@ hb-shape, see HarfBUzz documentation:
 java.awt.font.GlyphVector
     Positioning is possible using glyph positions (relative to origin of text) using MOVE_TEXT (newLineAtOffset()).
             Point2D p = awtGlyphVector.getGlyphPosition(i);
-    AdvanceX is needed for positionung using SHOW_TEXT_ADJUSTED (showTextWithPositioning())
+    AdvanceX is needed for positioning using SHOW_TEXT_ADJUSTED (showTextWithPositioning())
             float ax =  awtGlyphVector.getGlyphMetrics(i).getAdvanceX();
     AdvanceY is not needed for horizontal scripts.
 

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -69,7 +69,7 @@ Wird die nötige Info überhaupt aus dem Font ausgelesen?
  */
 public final class AdvancedTextLayoutSequencesDin91379
 {
-    public static String sequencesDin91379 = /*"xC̨̆x"; */
+    public static String sequencesDin91379 = /*"xC̆C̨̆x"; */
              "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n"
             + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
             + "T̈ T̕ T̛ U̇ Z̀ Z̄ Z̆ Z̈ Z̧ a̋ c̀ c̄ c̆ c̈ c̕ c̣ c̦ c̨̆ d̂ f̀ f̄ g̀ h̄ h̦ j́ k̀ \n"

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -15,15 +15,25 @@
  * limitations under the License.
  */
 
-/*XXX
-Comaring Java AWT layout vector and AdvancedLayout: factor 50 = 1000/(20=fontSize), y different sign
-Small diffenences, awt.Glyphlayout has data type float, AdvancedLayout integer
+/*
+Comparing Java AWT layout vector and AdvancedLayout: factor 50 = 1000/(20=fontSize), y different sign
+Small differences, awt.Glyphlayout has data type float, AdvancedLayout integer
 
-Comparison of glyph vector to hb-shape, see HarfBUzz documentation:
+hb-shape, see HarfBUzz documentation:
   hb_position_t x_offset;  how much the glyph moves on the X-axis before drawing it, this should not affect how much the line advances.
   hb_position_t y_offset;  how much the glyph moves on the Y-axis before drawing it, this should not affect how much the line advances.
   hb_position_t x_advance; how much the line advances after drawing this glyph when setting text in horizontal direction.
   hb_position_t y_advance; how much the line advances after drawing this glyph when setting text in vertical direction.
+
+java.awt.font.GlyphVector
+    Positioning is possible using glyph positions (relative to origin of text) using MOVE_TEXT (newLineAtOffset()).
+            Point2D p = awtGlyphVector.getGlyphPosition(i);
+    AdvanceX is needed for positionung using SHOW_TEXT_ADJUSTED (showTextWithPositioning())
+            float ax =  awtGlyphVector.getGlyphMetrics(i).getAdvanceX();
+    AdvanceY is not needed for horizontal scripts.
+
+GlyphVectorAdvanced
+    ???
 
 2022-05-28
   Error positioning double accents, e.g. "C̨̆" GlyphVectorAdvanced does not contain positioning information for the second accent.
@@ -62,7 +72,7 @@ import java.text.Bidi;
  */
 public final class AdvancedTextLayoutSequencesDin91379
 {
-    public static String sequencesDin91379 = /*"xC̆C̨̆x"; */
+    public static String sequencesDin91379 = "C̆C̨̆ C̨̆"; /*
              "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n"
             + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
             + "T̈ T̕ T̛ U̇ Z̀ Z̄ Z̆ Z̈ Z̧ a̋ c̀ c̄ c̆ c̈ c̕ c̣ c̦ c̨̆ d̂ f̀ f̄ g̀ h̄ h̦ j́ k̀ \n"

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -47,6 +47,16 @@ import java.io.File;
 import java.io.IOException;
 import java.text.AttributedString;
 import java.text.Bidi;
+/*
+XXXXXXXXX
+Fehler bei "C̨̆"
+Was passiert, wenn zwei diakrit. Zeichen aufeinanderfolgen?
+Was ist die aktuelle Stelle im Postscript-File nach
+[ ... ] TJ ?
+Wie soll der Glyphvektor aussehen?
+Zusammenfassen von Grundbuchstaben und danach kommenden Zeichen mit width==0 ?
+Wird die nötige Info überhaupt aus dem Font ausgelesen?
+ */
 
 /**
  * An example of using an embedded OpenType font with advanced glyph layout for
@@ -59,14 +69,15 @@ import java.text.Bidi;
  */
 public final class AdvancedTextLayoutSequencesDin91379
 {
-    public static String sequencesDin91379 = "A̋";
-/*             "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n";
+    public static String sequencesDin91379 = /*"xC̨̆x"; */
+             "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n"
             + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
             + "T̈ T̕ T̛ U̇ Z̀ Z̄ Z̆ Z̈ Z̧ a̋ c̀ c̄ c̆ c̈ c̕ c̣ c̦ c̨̆ d̂ f̀ f̄ g̀ h̄ h̦ j́ k̀ \n"
             + "k̂ k̄ k̇ k̕ k̛ k̦ k͟h l̂ l̥ l̥̄ l̦ m̀ m̂ m̆ m̐ n̂ n̄ n̆ n̦ p̀ p̄ p̕ p̣ r̆ r̥ r̥̄ \n"
             + "s̀ s̄ s̛̄ s̱ t̀ t̄ t̕ t̛ u̇ z̀ z̄ z̆ z̈ z̧ Ç̆ Û̄ ç̆ û̄ ÿ́ Č̕ Č̣ č̕ č̣ Ī́ ī́ Ž̦ \n"
             + "Ž̧ ž̦ ž̧ Ḳ̄ ḳ̄ Ṣ̄ ṣ̄ Ṭ̄ ṭ̄ Ạ̈ ạ̈ Ọ̈ ọ̈ Ụ̄ Ụ̈ ụ̄ ụ̈ \n";
-*/
+/**/
+
     private AdvancedTextLayoutSequencesDin91379()
     {
     }
@@ -79,20 +90,24 @@ public final class AdvancedTextLayoutSequencesDin91379
         String dir = args[0];
         String[] fontFileNames = new String[] {
                 "NotoSans-Regular.ttf",
-                "LiberationSans-Regular.ttf",
+           /*     "LiberationSans-Regular.ttf",
                 "DejaVuSans.ttf",
                 "IBMPlexSans-Regular.ttf",
                 "SourceSans3-Regular.ttf",
-        };
-        float fontSize = 20f;
 
-        for (String fontFileName : fontFileNames) {
-            try {
-                System.out.printf("--font:%s%n", fontFileName);
-                testJava2D(dir, fontFileName, fontSize, sequencesDin91379);
-                testAdvancedLayout(dir, fontFileName, fontSize, sequencesDin91379);
-            } catch (Exception ee) {
-                ee.printStackTrace();
+            */
+        };
+        float[] fontSizes = new float[]{20f};
+
+        for (float fontSize: fontSizes) {
+            for (String fontFileName : fontFileNames) {
+                try {
+                    System.out.printf("--font:%s%n", fontFileName);
+                    testJava2D(dir, fontFileName, fontSize, sequencesDin91379);
+                    testAdvancedLayout(dir, fontFileName, fontSize, sequencesDin91379);
+                } catch (Exception ee) {
+                    ee.printStackTrace();
+                }
             }
         }
     }
@@ -101,19 +116,23 @@ public final class AdvancedTextLayoutSequencesDin91379
 
         try {
             PDDocument pdDocument = new PDDocument();
-            PDPage blankPage = new PDPage();
-            pdDocument.addPage(blankPage);
+            PDPage page = new PDPage();
+            pdDocument.addPage(page);
             PDPageContentStream cs = new PDPageContentStream(pdDocument, pdDocument.getPage(0),
                     PDPageContentStream.AppendMode.APPEND, true);
 
             File fontFile = new File(dir + "/" + fontFileName );
             PDType0Font font = PDType0Font.load(pdDocument, fontFile);
             Font awtFont = Font.createFont(Font.TRUETYPE_FONT, fontFile).deriveFont(fontSize);
-            float x = blankPage.getBBox().getLowerLeftX();
-            float y = blankPage.getBBox().getUpperRightY() - awtFont.getSize2D();
+            float x = page.getBBox().getLowerLeftX();
+            float y = page.getBBox().getUpperRightY() - awtFont.getSize2D();
+            System.out.printf("testJava2D ur=%f h=%f %n", page.getBBox().getUpperRightY(), awtFont.getSize2D());
+            System.out.printf("testJava2D (x,y)=(%f, %f)%n", x, y);
+
+
             testSequences2D(cs, font, fontSize, awtFont, x, y, s);
             cs.close();
-            pdDocument.save(String.format("%s/TestDin91379Java2D-%s-.pdf", dir, fontFileName));
+            pdDocument.save(String.format("%s/TestDin91379Java2D-%s-%s.pdf", dir, fontFileName, fontSize));
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -129,7 +148,7 @@ public final class AdvancedTextLayoutSequencesDin91379
             if (line.length() > 0) {
                 testSequencesLine2D(cs, font, fontSize, awtFont, line, x, y);
             }
-            y -= awtFont.getSize2D() * 0.65;
+            y -= awtFont.getSize2D()*1.2f;
         }
     }
 
@@ -146,7 +165,7 @@ public final class AdvancedTextLayoutSequencesDin91379
             Point2D p = awtGlyphVector.getGlyphPosition(i);
             float ax =  awtGlyphVector.getGlyphMetrics(i).getAdvanceX();
             float ay =  awtGlyphVector.getGlyphMetrics(i).getAdvanceY();
-            float factor = 1000f/fontSize;
+            float factor = 1000f/fontSize; //XXX oder 72 ??
             System.out.printf("px=%f py=%f ", p.getX()*factor, p.getY()*factor);
             System.out.printf("ax=%f ay=%f ", ax*factor, ay*factor);
             System.out.printf("dx=%f dy=%f %n", (p.getX() - lastX -lastAx)*factor, (p.getY() - lastY -lastAy)*factor);
@@ -169,9 +188,34 @@ public final class AdvancedTextLayoutSequencesDin91379
         AttributedString as = new AttributedString(line);
         Bidi bidi = new Bidi(as.getIterator());
         int localFlags = bidi.isLeftToRight() ? java.awt.Font.LAYOUT_LEFT_TO_RIGHT : java.awt.Font.LAYOUT_RIGHT_TO_LEFT;
-        java.awt.font.GlyphVector glyphVector = awtFont.layoutGlyphVector(fontRenderContext, chars, 0, chars.length, localFlags);
-        printAdjustments2D(line, glyphVector, fontSize);
+        java.awt.font.GlyphVector awtGlyphVector = awtFont.layoutGlyphVector(fontRenderContext, chars, 0, chars.length, localFlags);
+        printAdjustments2D(line, awtGlyphVector, fontSize);
 
+        // cs.showGlyphVector(...)
+        int[] glyphs = awtGlyphVector.getGlyphCodes(0, awtGlyphVector.getNumGlyphs(), null);
+        int width = 0;
+        int[][] adjustments = new int[awtGlyphVector.getNumGlyphs()][4];
+        int lastX = 0;
+        int lastAdvanceX = 0;
+        for( int i=0; i<awtGlyphVector.getNumGlyphs(); i+=1) {
+            int px = (int) (awtGlyphVector.getGlyphPosition(i).getX()*1000/fontSize);
+            adjustments[i][0] = lastX = px - lastX - lastAdvanceX;
+            adjustments[i][1] = -(int)Math.round(awtGlyphVector.getGlyphPosition(i).getY()*1000/fontSize);
+            adjustments[i][2] = lastAdvanceX = (int) Math.round(awtGlyphVector.getGlyphMetrics(i).getAdvanceX()*1000/fontSize);
+            adjustments[i][3] = (int) Math.round(awtGlyphVector.getGlyphMetrics(i).getAdvanceY()*1000/fontSize);
+            lastX = px;
+            lastAdvanceX = adjustments[i][2];
+            width += adjustments[i][2];
+        }
+        GlyphVectorAdvanced vector = new GlyphVectorAdvanced(glyphs, width, adjustments);
+        System.out.printf("2d GlyphVectorAdvanced=%s%n", vector);
+
+        cs.beginText();
+        cs.setFont(font, fontSize);
+        cs.newLineAtOffset(x, y);
+        cs.showGlyphVector(vector);
+        cs.endText();
+/*
         cs.beginText();
         cs.setFont(font, fontSize);
         cs.newLineAtOffset(x, y);
@@ -193,6 +237,7 @@ public final class AdvancedTextLayoutSequencesDin91379
             lastY = (float) p.getY();
         }
         cs.endText();
+  */
     }
 
     private static Matrix createMatrix(float translateX, float translateY) {
@@ -232,26 +277,35 @@ public final class AdvancedTextLayoutSequencesDin91379
             PDFont font = PDType0Font.load(document, otFont, true);
 
             GlyphVector vector;
-            float x = 10;
+            float x = page.getBBox().getLowerLeftX();
+            float y = page.getBBox().getUpperRightY() - otFont.getFontBBox().getHeight()/72;
+            System.out.printf("ur=%f h=%f %n", page.getBBox().getUpperRightY(), otFont.getFontBBox().getHeight());
+            System.out.printf("(x,y)=(%f, %f)%n", x, y);
+
 
             try (PDPageContentStream stream = new PDPageContentStream(document, page))
             {
                 stream.beginText();
                 stream.setFont(font, fontSize);
+                stream.newLineAtOffset(x, y);
+
 
                 s = s.replaceAll("[ \t]", " ");
                 String[] lines = s.split("\n");
 
                 for (String line : lines) {
                     if (line.length() > 0) {
-                        vector = otFont.createGlyphVector(line);
+                        vector = otFont.createGlyphVector(line, (int)fontSize);
+                        System.out.printf("fontbox vector=%s%n",vector.toString());
                         printAdjustmentsAdvancedLayout(line, vector);
-                        stream.showGlyphVector(vector, createMatrix(x, 200));
+                        stream.showGlyphVector(vector);
                     }
+                    stream.newLineAtOffset(0, -24);
+                    System.out.printf("(x,y)=(%f, %f) l=%s%n", x, y, line);
                 }
                 stream.endText();
             }
-            document.save(String.format("%s/TestDin91379AdvancedLayout-%s-.pdf", dir, fontFileName));
+            document.save(String.format("%s/TestDin91379AdvancedLayout-%s-%s.pdf", dir, fontFileName, fontSize));
         }
     }
 }

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -72,7 +72,7 @@ import java.text.Bidi;
  */
 public final class AdvancedTextLayoutSequencesDin91379
 {
-    public static String sequencesDin91379 = /* "C̨̆x"; */
+    public static String sequencesDin91379 =  /*"C̨̆x"; */
              "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n"
             + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
             + "T̈ T̕ T̛ U̇ Z̀ Z̄ Z̆ Z̈ Z̧ a̋ c̀ c̄ c̆ c̈ c̕ c̣ c̦ c̨̆ d̂ f̀ f̄ g̀ h̄ h̦ j́ k̀ \n"
@@ -206,7 +206,6 @@ public final class AdvancedTextLayoutSequencesDin91379
         printAdjustments2D(line, awtGlyphVector, fontSize);
 
         int[] glyphs = awtGlyphVector.getGlyphCodes(0, awtGlyphVector.getNumGlyphs(), null);
-        int width = 0;
         int[][] adjustments = new int[awtGlyphVector.getNumGlyphs()][4];
         int currentXPosition = 0; /* only changed by advanceX */
         System.out.printf("i  code px currentXPosition dx   dy   ax   ay%n");
@@ -214,14 +213,14 @@ public final class AdvancedTextLayoutSequencesDin91379
             int px = (int) (awtGlyphVector.getGlyphPosition(i).getX()*1000/fontSize);
             int dx = adjustments[i][0] = px - currentXPosition;
             int dy = adjustments[i][1] = -(int)Math.round(awtGlyphVector.getGlyphPosition(i).getY()*1000/fontSize);
-            int ax = adjustments[i][2] = (int) Math.round(awtGlyphVector.getGlyphMetrics(i).getAdvanceX()*1000/fontSize);
-            int ay = adjustments[i][3] = (int) Math.round(awtGlyphVector.getGlyphMetrics(i).getAdvanceY()*1000/fontSize);
-            currentXPosition += adjustments[i][2];
-            width += adjustments[i][2];
+            int ax = adjustments[i][2] = 0;
+            int ay = adjustments[i][3] = 0;
+            currentXPosition += (int) Math.round(awtGlyphVector.getGlyphMetrics(i).getAdvanceX()*1000/fontSize);;
             System.out.printf("%d\t%h\t%d\t%d\t%d\t%d\t%d\t%d%n",
                     i, awtGlyphVector.getGlyphCharIndex(i), px, currentXPosition, dx, dy, ax, ay);
 
         }
+        int width = (int) Math.round(awtGlyphVector.getGlyphPosition(awtGlyphVector.getNumGlyphs()).getX()*1000/fontSize);
         GlyphVectorAdvanced vector = new GlyphVectorAdvanced(glyphs, width, adjustments);
         System.out.printf("2d GlyphVectorAdvanced=%s%n", vector);
 

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -72,7 +72,7 @@ import java.text.Bidi;
  */
 public final class AdvancedTextLayoutSequencesDin91379
 {
-    public static String sequencesDin91379 = /* "C̆C̨̆ C̨̆"; */
+    public static String sequencesDin91379 = /* "C̨̆x"; */
              "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n"
             + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
             + "T̈ T̕ T̛ U̇ Z̀ Z̄ Z̆ Z̈ Z̧ a̋ c̀ c̄ c̆ c̈ c̕ c̣ c̦ c̨̆ d̂ f̀ f̄ g̀ h̄ h̦ j́ k̀ \n"
@@ -208,17 +208,19 @@ public final class AdvancedTextLayoutSequencesDin91379
         int[] glyphs = awtGlyphVector.getGlyphCodes(0, awtGlyphVector.getNumGlyphs(), null);
         int width = 0;
         int[][] adjustments = new int[awtGlyphVector.getNumGlyphs()][4];
-        int lastX = 0;
-        int lastAdvanceX = 0;
+        int currentXPosition = 0; /* only changed by advanceX */
+        System.out.printf("i  code px currentXPosition dx   dy   ax   ay%n");
         for( int i=0; i<awtGlyphVector.getNumGlyphs(); i+=1) {
             int px = (int) (awtGlyphVector.getGlyphPosition(i).getX()*1000/fontSize);
-            adjustments[i][0] = lastX = px - lastX - lastAdvanceX;
-            adjustments[i][1] = -(int)Math.round(awtGlyphVector.getGlyphPosition(i).getY()*1000/fontSize);
-            adjustments[i][2] = lastAdvanceX = (int) Math.round(awtGlyphVector.getGlyphMetrics(i).getAdvanceX()*1000/fontSize);
-            adjustments[i][3] = (int) Math.round(awtGlyphVector.getGlyphMetrics(i).getAdvanceY()*1000/fontSize);
-            lastX = px;
-            lastAdvanceX = adjustments[i][2];
+            int dx = adjustments[i][0] = px - currentXPosition;
+            int dy = adjustments[i][1] = -(int)Math.round(awtGlyphVector.getGlyphPosition(i).getY()*1000/fontSize);
+            int ax = adjustments[i][2] = (int) Math.round(awtGlyphVector.getGlyphMetrics(i).getAdvanceX()*1000/fontSize);
+            int ay = adjustments[i][3] = (int) Math.round(awtGlyphVector.getGlyphMetrics(i).getAdvanceY()*1000/fontSize);
+            currentXPosition += adjustments[i][2];
             width += adjustments[i][2];
+            System.out.printf("%d\t%h\t%d\t%d\t%d\t%d\t%d\t%d%n",
+                    i, awtGlyphVector.getGlyphCharIndex(i), px, currentXPosition, dx, dy, ax, ay);
+
         }
         GlyphVectorAdvanced vector = new GlyphVectorAdvanced(glyphs, width, adjustments);
         System.out.printf("2d GlyphVectorAdvanced=%s%n", vector);

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -72,7 +72,7 @@ import java.text.Bidi;
  */
 public final class AdvancedTextLayoutSequencesDin91379
 {
-    public static String sequencesDin91379 = "C̆C̨̆ C̨̆"; /*
+    public static String sequencesDin91379 = /* "C̆C̨̆ C̨̆"; */
              "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n"
             + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
             + "T̈ T̕ T̛ U̇ Z̀ Z̄ Z̆ Z̈ Z̧ a̋ c̀ c̄ c̆ c̈ c̕ c̣ c̦ c̨̆ d̂ f̀ f̄ g̀ h̄ h̦ j́ k̀ \n"

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -35,6 +35,8 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.io.File;
 import java.io.IOException;
+import java.text.AttributedString;
+import java.text.Bidi;
 
 /**
  * An example of using an embedded OpenType font with advanced glyph layout for
@@ -101,7 +103,6 @@ public final class AdvancedTextLayoutSequencesDin91379
             testSequences2D(cs, font, fontSize, awtFont, x, y, s);
             cs.close();
             pdDocument.save(String.format("%s/TestDin91379Java2D-%s-.pdf", dir, fontFileName));
-            pdDocument.close();
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -147,9 +148,13 @@ public final class AdvancedTextLayoutSequencesDin91379
                                           float fontSize, Font awtFont, String line, float x, float y) throws IOException {
         char[] chars = line.toCharArray();
         // Use Java2D to compute positioning of glyphs
+
         FontRenderContext fontRenderContext = new FontRenderContext(new AffineTransform(), false, true);
-        java.awt.font.GlyphVector glyphVector = awtFont.layoutGlyphVector(fontRenderContext, chars, 0, chars.length,
-                Font.LAYOUT_LEFT_TO_RIGHT);
+        // specify fractional metrics to compute accurate positions
+        AttributedString as = new AttributedString(line);
+        Bidi bidi = new Bidi(as.getIterator());
+        int localFlags = bidi.isLeftToRight() ? java.awt.Font.LAYOUT_LEFT_TO_RIGHT : java.awt.Font.LAYOUT_RIGHT_TO_LEFT;
+        java.awt.font.GlyphVector glyphVector = awtFont.layoutGlyphVector(fontRenderContext, chars, 0, chars.length, localFlags);
         printAdjustmentsAdvancedLayout(line, glyphVector);
 
         cs.beginText();
@@ -192,7 +197,7 @@ public final class AdvancedTextLayoutSequencesDin91379
                     System.out.printf("%d ", adjustments[i][j]);
                 }
             } else {
-                System.out.printf("no adjustments ");
+                System.out.print("no adjustments ");
             }
             System.out.println();
         }
@@ -233,7 +238,6 @@ public final class AdvancedTextLayoutSequencesDin91379
                 stream.endText();
             }
             document.save(String.format("%s/TestDin91379AdvancedLayout-%s-.pdf", dir, fontFileName));
-            document.close();
         }
     }
 }

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -49,9 +49,9 @@ import java.text.Bidi;
  */
 public final class AdvancedTextLayoutSequencesDin91379
 {
-    public static String sequencesDin91379 =
-             "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n";
-/*            + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
+    public static String sequencesDin91379 = "A̋";
+/*             "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n";
+            + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
             + "T̈ T̕ T̛ U̇ Z̀ Z̄ Z̆ Z̈ Z̧ a̋ c̀ c̄ c̆ c̈ c̕ c̣ c̦ c̨̆ d̂ f̀ f̄ g̀ h̄ h̦ j́ k̀ \n"
             + "k̂ k̄ k̇ k̕ k̛ k̦ k͟h l̂ l̥ l̥̄ l̦ m̀ m̂ m̆ m̐ n̂ n̄ n̆ n̦ p̀ p̄ p̕ p̣ r̆ r̥ r̥̄ \n"
             + "s̀ s̄ s̛̄ s̱ t̀ t̄ t̕ t̛ u̇ z̀ z̄ z̆ z̈ z̧ Ç̆ Û̄ ç̆ û̄ ÿ́ Č̕ Č̣ č̕ č̣ Ī́ ī́ Ž̦ \n"
@@ -74,18 +74,20 @@ public final class AdvancedTextLayoutSequencesDin91379
                 "IBMPlexSans-Regular.ttf",
                 "SourceSans3-Regular.ttf",
         };
+        float fontSize = 20f;
+
         for (String fontFileName : fontFileNames) {
             try {
                 System.out.printf("--font:%s%n", fontFileName);
-                testJava2D(dir, fontFileName, sequencesDin91379);
-                testAdvancedLayout(dir, fontFileName, sequencesDin91379);
+                testJava2D(dir, fontFileName, fontSize, sequencesDin91379);
+                testAdvancedLayout(dir, fontFileName, fontSize, sequencesDin91379);
             } catch (Exception ee) {
                 ee.printStackTrace();
             }
         }
     }
 
-    public static void testJava2D(String dir, String fontFileName, String s) {
+    public static void testJava2D(String dir, String fontFileName, float fontSize, String s) {
 
         try {
             PDDocument pdDocument = new PDDocument();
@@ -96,7 +98,6 @@ public final class AdvancedTextLayoutSequencesDin91379
 
             File fontFile = new File(dir + "/" + fontFileName );
             PDType0Font font = PDType0Font.load(pdDocument, fontFile);
-            float fontSize = 12;
             Font awtFont = Font.createFont(Font.TRUETYPE_FONT, fontFile).deriveFont(fontSize);
             float x = blankPage.getBBox().getLowerLeftX();
             float y = blankPage.getBBox().getUpperRightY() - awtFont.getSize2D();
@@ -135,8 +136,9 @@ public final class AdvancedTextLayoutSequencesDin91379
             float dy = (float) p.getY() - lastY;
             float ax = (i == 0) ? 0.0f : awtGlyphVector.getGlyphMetrics(i - 1).getAdvanceX();
             float ay = (i == 0) ? 0.0f : awtGlyphVector.getGlyphMetrics(i - 1).getAdvanceY();
-            System.out.printf("%f %f %f ", dx, ax, dx-ax);
-            System.out.printf("%f %f %f\n", dy, ay, dy-ay);
+            float factor=50; // ???
+            System.out.printf("px=%f py=%f ", p.getX()*factor, p.getY()*factor);
+            System.out.printf("ax=%f ay=%f dx=%f dy=%f\n", ax*factor, ay*factor, dx*factor, dy*factor);
             System.out.println();
             lastX = (float) p.getX();
             lastY = (float) p.getY();
@@ -193,9 +195,9 @@ public final class AdvancedTextLayoutSequencesDin91379
         for (int i=0; i<gids.length; i++) {
             System.out.printf("%d %d ", i, gids[i]);
             if(adjustments!=null && adjustments[i]!=null) {
-                for (int j = 0; j < adjustments[i].length; j++) {
-                    System.out.printf("%d ", adjustments[i][j]);
-                }
+                System.out.printf("px=%d py=%d ax=%d ay=%d%n",
+                        adjustments[i][0], adjustments[i][1],
+                        adjustments[i][2], adjustments[i][3]);
             } else {
                 System.out.print("no adjustments ");
             }
@@ -203,7 +205,7 @@ public final class AdvancedTextLayoutSequencesDin91379
         }
     }
 
-    public static void testAdvancedLayout(String dir, String fontFileName, String s) throws IOException
+    public static void testAdvancedLayout(String dir, String fontFileName, float fontSize, String s) throws IOException
     {
         try (PDDocument document = new PDDocument())
         {
@@ -221,7 +223,6 @@ public final class AdvancedTextLayoutSequencesDin91379
 
             try (PDPageContentStream stream = new PDPageContentStream(document, page))
             {
-                float fontSize = 20;
                 stream.beginText();
                 stream.setFont(font, fontSize);
 

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -67,7 +67,10 @@ public final class AdvancedTextLayoutSequencesDin91379
         try {
             String dir = args[0];
 
-            String fontFileName = "/NotoSans-Regular.ttf";
+            //String fontFileName = "/NotoSans-Regular.ttf";
+            //String fontFileName = "/LiberationSans-Regular.ttf";
+            String fontFileName = "/DejaVuSans.ttf";
+
             testJava2D(dir, fontFileName, sequencesDin91379);
             testAdvancedLayout(dir, fontFileName, sequencesDin91379);
         } catch (Exception e) {
@@ -179,8 +182,12 @@ public final class AdvancedTextLayoutSequencesDin91379
         System.out.println(line);
         for (int i=0; i<gids.length; i++) {
             System.out.printf("%d %d ", i, gids[i]);
-            for (int j=0; j<adjustments[i].length; j++) {
-                System.out.printf("%d ", adjustments[i][j]);
+            if(adjustments!=null && adjustments[i]!=null) {
+                for (int j = 0; j < adjustments[i].length; j++) {
+                    System.out.printf("%d ", adjustments[i][j]);
+                }
+            } else {
+                System.out.printf("no adjustments ");
             }
             System.out.println();
         }

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -15,31 +15,16 @@
  * limitations under the License.
  */
 
-/* XXXXXXXXXXxxy
-volker@volker-LIFEBOOK-E556:~/work$ hb-shape --font-file SourceSans3-Regular.ttf  --output-format json <a_double_acute_accent.txt
-[{"g":"A","cl":0,"dx":0,"dy":0,"ax":544,"ay":0},
-{"g":"uni030B.c","cl":0,"dx":-273,"dy":0,"ax":0,"ay":0}]
+/*XXX
+Comaring Java AWT layout vector and AdvancedLayout: factor 50 = 1000/(20=fontSize), y different sign
+Small diffenences, awt.Glyphlayout has data type float, AdvancedLayout integer
 
-hb-shape --font-file NotoSans-Regular.ttf --font-size 20 --output-format json <a_double_acute_accent.txt
-[{"g":"A","cl":0,"dx":0,"dy":0,"ax":41,"ay":0},
- {"g":"uni030B","cl":0,"dx":-36,"dy":4,"ax":0,"ay":0}]
-
-volker@volker-LIFEBOOK-E556:~/work$ hb-shape --font-file NotoSans-Regular.ttf  --output-format json <a_double_acute_accent.txt
-[{"g":"A","cl":0,"dx":0,"dy":0,"ax":639,"ay":0},
- {"g":"uni030B","cl":0,"dx":-375,"dy":178,"ax":0,"ay":0}]
-
-?????
-
-Im Vergleich zu AdvancedLayout: Faktor 50 = 1000/(20=fontSize), y anderes Vorzeichen
-kleine Abweichungen, da awt.Glyphlayout float  und bei AdvancedLayout integer
-
-Vergleich von AWT Glyphvektor zu hb-shape ???
+Comparison of AWT glyph vector to hb-shape
 hb_position_t x_advance; how much the line advances after drawing this glyph when setting text in horizontal direction.
 hb_position_t y_advance; how much the line advances after drawing this glyph when setting text in vertical direction.
 hb_position_t x_offset;  how much the glyph moves on the X-axis before drawing it, this should not affect how much the line advances.
 hb_position_t y_offset;  how much the glyph moves on the Y-axis before drawing it, this should not affect how much the line advances.
-
- XXXXXXXXXXXXXXXXXXX */
+*/
 package org.apache.pdfbox.examples.pdmodel;
 
 import org.apache.fontbox.ttf.advanced.api.GlyphVector;

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -17,10 +17,12 @@
 
 package org.apache.pdfbox.examples.pdmodel;
 
-import org.apache.fontbox.ttf.GlyphVector;
 import org.apache.fontbox.ttf.OTFParser;
 import org.apache.fontbox.ttf.OpenTypeFont;
+import org.apache.fontbox.ttf.advanced.api.GlyphVector;
 import org.apache.fontbox.ttf.advanced.GlyphVectorAdvanced;
+import org.apache.fontbox.ttf.advanced.api.AdvancedOTFParser;
+import org.apache.fontbox.ttf.advanced.api.AdvancedOpenTypeFont;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -207,8 +209,8 @@ public final class AdvancedTextLayoutSequencesDin91379
 
             String fontFile = dir + "/" + fontFileName;
 
-            OTFParser fontParser = new OTFParser(true, false, true);
-            OpenTypeFont otFont = fontParser.parse(fontFile);
+            AdvancedOTFParser fontParser = new AdvancedOTFParser();
+            AdvancedOpenTypeFont otFont = fontParser.parse(fontFile);
             PDFont font = PDType0Font.load(document, otFont, true);
 
             GlyphVector vector;

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -15,6 +15,30 @@
  * limitations under the License.
  */
 
+/* XXXXXXXXXXxx
+volker@volker-LIFEBOOK-E556:~/work$ hb-shape --font-file SourceSans3-Regular.ttf  --output-format json <a_double_acute_accent.txt
+[{"g":"A","cl":0,"dx":0,"dy":0,"ax":544,"ay":0},
+{"g":"uni030B.c","cl":0,"dx":-273,"dy":0,"ax":0,"ay":0}]
+
+hb-shape --font-file NotoSans-Regular.ttf --font-size 20 --output-format json <a_double_acute_accent.txt
+[{"g":"A","cl":0,"dx":0,"dy":0,"ax":41,"ay":0},
+ {"g":"uni030B","cl":0,"dx":-36,"dy":4,"ax":0,"ay":0}]
+
+volker@volker-LIFEBOOK-E556:~/work$ hb-shape --font-file NotoSans-Regular.ttf  --output-format json <a_double_acute_accent.txt
+[{"g":"A","cl":0,"dx":0,"dy":0,"ax":639,"ay":0},
+ {"g":"uni030B","cl":0,"dx":-375,"dy":178,"ax":0,"ay":0}]
+
+?????
+
+Im Vergleich zu AdvancedLayout: Faktor 50, y anderes Vorzeichen
+
+Vergleich von AWT Glyphvektor zu hb-shape ???
+hb_position_t x_advance; how much the line advances after drawing this glyph when setting text in horizontal direction.
+hb_position_t y_advance; how much the line advances after drawing this glyph when setting text in vertical direction.
+hb_position_t x_offset;  how much the glyph moves on the X-axis before drawing it, this should not affect how much the line advances.
+hb_position_t y_offset;  how much the glyph moves on the Y-axis before drawing it, this should not affect how much the line advances.
+
+ XXXXXXXXXXXXXXXXXXX */
 package org.apache.pdfbox.examples.pdmodel;
 
 import org.apache.fontbox.ttf.advanced.api.GlyphVector;
@@ -129,19 +153,23 @@ public final class AdvancedTextLayoutSequencesDin91379
         System.out.println(line);
         float lastX = 0f;
         float lastY = 0f;
+        float lastAx = 0f;
+        float lastAy = 0f;
         for (int i=0; i<gids.length; i++) {
             System.out.printf("%d %d ", i, gids[i]);
             Point2D p = awtGlyphVector.getGlyphPosition(i);
             float dx = (float) p.getX() - lastX;
             float dy = (float) p.getY() - lastY;
-            float ax = (i == 0) ? 0.0f : awtGlyphVector.getGlyphMetrics(i - 1).getAdvanceX();
-            float ay = (i == 0) ? 0.0f : awtGlyphVector.getGlyphMetrics(i - 1).getAdvanceY();
-            float factor=50; // ???
-            System.out.printf("px=%f py=%f ", p.getX()*factor, p.getY()*factor);
-            System.out.printf("ax=%f ay=%f dx=%f dy=%f\n", ax*factor, ay*factor, dx*factor, dy*factor);
+            float ax =  awtGlyphVector.getGlyphMetrics(i).getAdvanceX();
+            float ay =  awtGlyphVector.getGlyphMetrics(i).getAdvanceY();
+            System.out.printf("px=%f py=%f ", p.getX(), p.getY());
+            System.out.printf("ax=%f ay=%f ", ax, ay);
+            System.out.printf("dx=%f dy=%f %n", p.getX() - lastX -lastAx, p.getY() - lastY -lastAy);
             System.out.println();
             lastX = (float) p.getX();
             lastY = (float) p.getY();
+            lastAx = ax;
+            lastAy = ay;
         }
     }
 

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -30,7 +30,8 @@ volker@volker-LIFEBOOK-E556:~/work$ hb-shape --font-file NotoSans-Regular.ttf  -
 
 ?????
 
-Im Vergleich zu AdvancedLayout: Faktor 50, y anderes Vorzeichen
+Im Vergleich zu AdvancedLayout: Faktor 50 = 1000/(20=fontSize), y anderes Vorzeichen
+kleine Abweichungen, da awt.Glyphlayout float  und bei AdvancedLayout integer
 
 Vergleich von AWT Glyphvektor zu hb-shape ???
 hb_position_t x_advance; how much the line advances after drawing this glyph when setting text in horizontal direction.
@@ -147,7 +148,7 @@ public final class AdvancedTextLayoutSequencesDin91379
         }
     }
 
-    public static void printAdjustmentsAdvancedLayout(String line, java.awt.font.GlyphVector awtGlyphVector) {
+    public static void printAdjustmentsAdvancedLayout(String line, java.awt.font.GlyphVector awtGlyphVector, float fontSize) {
         int[] gids = awtGlyphVector.getGlyphCodes(0, awtGlyphVector.getNumGlyphs(), null);
         System.out.println("--Java2D--");
         System.out.println(line);
@@ -158,13 +159,12 @@ public final class AdvancedTextLayoutSequencesDin91379
         for (int i=0; i<gids.length; i++) {
             System.out.printf("%d %d ", i, gids[i]);
             Point2D p = awtGlyphVector.getGlyphPosition(i);
-            float dx = (float) p.getX() - lastX;
-            float dy = (float) p.getY() - lastY;
             float ax =  awtGlyphVector.getGlyphMetrics(i).getAdvanceX();
             float ay =  awtGlyphVector.getGlyphMetrics(i).getAdvanceY();
-            System.out.printf("px=%f py=%f ", p.getX(), p.getY());
-            System.out.printf("ax=%f ay=%f ", ax, ay);
-            System.out.printf("dx=%f dy=%f %n", p.getX() - lastX -lastAx, p.getY() - lastY -lastAy);
+            float factor = 1000f/fontSize;
+            System.out.printf("px=%f py=%f ", p.getX()*factor, p.getY()*factor);
+            System.out.printf("ax=%f ay=%f ", ax*factor, ay*factor);
+            System.out.printf("dx=%f dy=%f %n", (p.getX() - lastX -lastAx)*factor, (p.getY() - lastY -lastAy)*factor);
             System.out.println();
             lastX = (float) p.getX();
             lastY = (float) p.getY();
@@ -185,7 +185,7 @@ public final class AdvancedTextLayoutSequencesDin91379
         Bidi bidi = new Bidi(as.getIterator());
         int localFlags = bidi.isLeftToRight() ? java.awt.Font.LAYOUT_LEFT_TO_RIGHT : java.awt.Font.LAYOUT_RIGHT_TO_LEFT;
         java.awt.font.GlyphVector glyphVector = awtFont.layoutGlyphVector(fontRenderContext, chars, 0, chars.length, localFlags);
-        printAdjustmentsAdvancedLayout(line, glyphVector);
+        printAdjustmentsAdvancedLayout(line, glyphVector, fontSize);
 
         cs.beginText();
         cs.setFont(font, fontSize);

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -64,17 +64,22 @@ public final class AdvancedTextLayoutSequencesDin91379
         if (args.length < 1) {
             throw new RuntimeException("Usage AdvancedTextLayoutSequencesDin91379 directory");
         }
-        try {
-            String dir = args[0];
-
-            //String fontFileName = "/NotoSans-Regular.ttf";
-            //String fontFileName = "/LiberationSans-Regular.ttf";
-            String fontFileName = "/DejaVuSans.ttf";
-
-            testJava2D(dir, fontFileName, sequencesDin91379);
-            testAdvancedLayout(dir, fontFileName, sequencesDin91379);
-        } catch (Exception e) {
-            e.printStackTrace();
+        String dir = args[0];
+        String[] fontFileNames = new String[] {
+                "NotoSans-Regular.ttf",
+                "LiberationSans-Regular.ttf",
+                "DejaVuSans.ttf",
+                "IBMPlexSans-Regular.ttf",
+                "SourceSans3-Regular.ttf",
+        };
+        for (String fontFileName : fontFileNames) {
+            try {
+                System.out.printf("--font:%s%n", fontFileName);
+                testJava2D(dir, fontFileName, sequencesDin91379);
+                testAdvancedLayout(dir, fontFileName, sequencesDin91379);
+            } catch (Exception ee) {
+                ee.printStackTrace();
+            }
         }
     }
 
@@ -95,7 +100,7 @@ public final class AdvancedTextLayoutSequencesDin91379
             float y = blankPage.getBBox().getUpperRightY();
             testSequences2D(cs, font, fontSize, awtFont, x, y, s);
             cs.close();
-            pdDocument.save(dir + "/TestDin91379Java2D.pdf");
+            pdDocument.save(String.format("%s/TestDin91379Java2D-%s-.pdf", dir, fontFileName));
             pdDocument.close();
         } catch (Exception e) {
             e.printStackTrace();
@@ -227,7 +232,7 @@ public final class AdvancedTextLayoutSequencesDin91379
                 }
                 stream.endText();
             }
-            document.save("TestDin91379AdvancedLayout.pdf");
+            document.save(String.format("%s/TestDin91379AdvancedLayout-%s-.pdf", dir, fontFileName));
             document.close();
         }
     }

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -133,7 +133,7 @@ public final class AdvancedTextLayoutSequencesDin91379
         }
     }
 
-    public static void printAdjustmentsAdvancedLayout(String line, java.awt.font.GlyphVector awtGlyphVector, float fontSize) {
+    public static void printAdjustments2D(String line, java.awt.font.GlyphVector awtGlyphVector, float fontSize) {
         int[] gids = awtGlyphVector.getGlyphCodes(0, awtGlyphVector.getNumGlyphs(), null);
         System.out.println("--Java2D--");
         System.out.println(line);
@@ -170,7 +170,7 @@ public final class AdvancedTextLayoutSequencesDin91379
         Bidi bidi = new Bidi(as.getIterator());
         int localFlags = bidi.isLeftToRight() ? java.awt.Font.LAYOUT_LEFT_TO_RIGHT : java.awt.Font.LAYOUT_RIGHT_TO_LEFT;
         java.awt.font.GlyphVector glyphVector = awtFont.layoutGlyphVector(fontRenderContext, chars, 0, chars.length, localFlags);
-        printAdjustmentsAdvancedLayout(line, glyphVector, fontSize);
+        printAdjustments2D(line, glyphVector, fontSize);
 
         cs.beginText();
         cs.setFont(font, fontSize);

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -17,8 +17,6 @@
 
 package org.apache.pdfbox.examples.pdmodel;
 
-import org.apache.fontbox.ttf.OTFParser;
-import org.apache.fontbox.ttf.OpenTypeFont;
 import org.apache.fontbox.ttf.advanced.api.GlyphVector;
 import org.apache.fontbox.ttf.advanced.GlyphVectorAdvanced;
 import org.apache.fontbox.ttf.advanced.api.AdvancedOTFParser;
@@ -49,14 +47,14 @@ import java.io.IOException;
  */
 public final class AdvancedTextLayoutSequencesDin91379
 {
-    public static String sequencesDin91379 = "Sequences\n"
-            + "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H n"
-            + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
+    public static String sequencesDin91379 =
+             "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H \n";
+/*            + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
             + "T̈ T̕ T̛ U̇ Z̀ Z̄ Z̆ Z̈ Z̧ a̋ c̀ c̄ c̆ c̈ c̕ c̣ c̦ c̨̆ d̂ f̀ f̄ g̀ h̄ h̦ j́ k̀ \n"
             + "k̂ k̄ k̇ k̕ k̛ k̦ k͟h l̂ l̥ l̥̄ l̦ m̀ m̂ m̆ m̐ n̂ n̄ n̆ n̦ p̀ p̄ p̕ p̣ r̆ r̥ r̥̄ \n"
             + "s̀ s̄ s̛̄ s̱ t̀ t̄ t̕ t̛ u̇ z̀ z̄ z̆ z̈ z̧ Ç̆ Û̄ ç̆ û̄ ÿ́ Č̕ Č̣ č̕ č̣ Ī́ ī́ Ž̦ \n"
             + "Ž̧ ž̦ ž̧ Ḳ̄ ḳ̄ Ṣ̄ ṣ̄ Ṭ̄ ṭ̄ Ạ̈ ạ̈ Ọ̈ ọ̈ Ụ̄ Ụ̈ ụ̄ ụ̈ \n";
-
+*/
     private AdvancedTextLayoutSequencesDin91379()
     {
     }
@@ -99,7 +97,7 @@ public final class AdvancedTextLayoutSequencesDin91379
             float fontSize = 12;
             Font awtFont = Font.createFont(Font.TRUETYPE_FONT, fontFile).deriveFont(fontSize);
             float x = blankPage.getBBox().getLowerLeftX();
-            float y = blankPage.getBBox().getUpperRightY();
+            float y = blankPage.getBBox().getUpperRightY() - awtFont.getSize2D();
             testSequences2D(cs, font, fontSize, awtFont, x, y, s);
             cs.close();
             pdDocument.save(String.format("%s/TestDin91379Java2D-%s-.pdf", dir, fontFileName));

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-/* XXXXXXXXXXxx
+/* XXXXXXXXXXxxy
 volker@volker-LIFEBOOK-E556:~/work$ hb-shape --font-file SourceSans3-Regular.ttf  --output-format json <a_double_acute_accent.txt
 [{"g":"A","cl":0,"dx":0,"dy":0,"ax":544,"ay":0},
 {"g":"uni030B.c","cl":0,"dx":-273,"dy":0,"ax":0,"ay":0}]

--- a/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
+++ b/examples/src/main/java/org/apache/pdfbox/examples/pdmodel/AdvancedTextLayoutSequencesDin91379.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pdfbox.examples.pdmodel;
+
+import org.apache.fontbox.ttf.GlyphVector;
+import org.apache.fontbox.ttf.OTFParser;
+import org.apache.fontbox.ttf.OpenTypeFont;
+import org.apache.fontbox.ttf.advanced.GlyphVectorAdvanced;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDType0Font;
+import org.apache.pdfbox.util.Matrix;
+
+import java.awt.*;
+import java.awt.font.FontRenderContext;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * An example of using an embedded OpenType font with advanced glyph layout for
+ * the sequences of DIN91379
+ *
+ *
+ * @author Volker Kunert
+ * @author Daniel Fickling
+ * @see AdvancedTextLayout
+ */
+public final class AdvancedTextLayoutSequencesDin91379
+{
+    public static String sequencesDin91379 = "Sequences\n"
+            + "A̋ C̀ C̄ C̆ C̈ C̕ C̣ C̦ C̨̆ D̂ F̀ F̄ G̀ H̄ H̦ H̱ J́ J̌ K̀ K̂ K̄ K̇ K̕ K̛ K̦ K͟H n"
+            + "K͟h L̂ L̥ L̥̄ L̦ M̀ M̂ M̆ M̐ N̂ N̄ N̆ N̦ P̀ P̄ P̕ P̣ R̆ R̥ R̥̄ S̀ S̄ S̛̄ S̱ T̀ T̄ \n"
+            + "T̈ T̕ T̛ U̇ Z̀ Z̄ Z̆ Z̈ Z̧ a̋ c̀ c̄ c̆ c̈ c̕ c̣ c̦ c̨̆ d̂ f̀ f̄ g̀ h̄ h̦ j́ k̀ \n"
+            + "k̂ k̄ k̇ k̕ k̛ k̦ k͟h l̂ l̥ l̥̄ l̦ m̀ m̂ m̆ m̐ n̂ n̄ n̆ n̦ p̀ p̄ p̕ p̣ r̆ r̥ r̥̄ \n"
+            + "s̀ s̄ s̛̄ s̱ t̀ t̄ t̕ t̛ u̇ z̀ z̄ z̆ z̈ z̧ Ç̆ Û̄ ç̆ û̄ ÿ́ Č̕ Č̣ č̕ č̣ Ī́ ī́ Ž̦ \n"
+            + "Ž̧ ž̦ ž̧ Ḳ̄ ḳ̄ Ṣ̄ ṣ̄ Ṭ̄ ṭ̄ Ạ̈ ạ̈ Ọ̈ ọ̈ Ụ̄ Ụ̈ ụ̄ ụ̈ \n";
+
+    private AdvancedTextLayoutSequencesDin91379()
+    {
+    }
+
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            throw new RuntimeException("Usage AdvancedTextLayoutSequencesDin91379 directory");
+        }
+        try {
+            String dir = args[0];
+
+            String fontFileName = "/NotoSans-Regular.ttf";
+            testJava2D(dir, fontFileName, sequencesDin91379);
+            testAdvancedLayout(dir, fontFileName, sequencesDin91379);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void testJava2D(String dir, String fontFileName, String s) {
+
+        try {
+            PDDocument pdDocument = new PDDocument();
+            PDPage blankPage = new PDPage();
+            pdDocument.addPage(blankPage);
+            PDPageContentStream cs = new PDPageContentStream(pdDocument, pdDocument.getPage(0),
+                    PDPageContentStream.AppendMode.APPEND, true);
+
+            File fontFile = new File(dir + "/" + fontFileName );
+            PDType0Font font = PDType0Font.load(pdDocument, fontFile);
+            float fontSize = 12;
+            Font awtFont = Font.createFont(Font.TRUETYPE_FONT, fontFile).deriveFont(fontSize);
+            float x = blankPage.getBBox().getLowerLeftX();
+            float y = blankPage.getBBox().getUpperRightY();
+            testSequences2D(cs, font, fontSize, awtFont, x, y, s);
+            cs.close();
+            pdDocument.save(dir + "/TestDin91379Java2D.pdf");
+            pdDocument.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void testSequences2D(PDPageContentStream cs, PDType0Font font,
+                                      float fontSize, Font awtFont, float x, float y, String s) throws Exception {
+
+        s = s.replaceAll("[ \t]", " ");
+        String[] lines = s.split("\n");
+
+        for (String line : lines) {
+            if (line.length() > 0) {
+                testSequencesLine2D(cs, font, fontSize, awtFont, line, x, y);
+            }
+            y -= awtFont.getSize2D() * 0.65;
+        }
+    }
+
+    public static void printAdjustmentsAdvancedLayout(String line, java.awt.font.GlyphVector awtGlyphVector) {
+        int[] gids = awtGlyphVector.getGlyphCodes(0, awtGlyphVector.getNumGlyphs(), null);
+        System.out.println("--Java2D--");
+        System.out.println(line);
+        float lastX = 0f;
+        float lastY = 0f;
+        for (int i=0; i<gids.length; i++) {
+            System.out.printf("%d %d ", i, gids[i]);
+            Point2D p = awtGlyphVector.getGlyphPosition(i);
+            float dx = (float) p.getX() - lastX;
+            float dy = (float) p.getY() - lastY;
+            float ax = (i == 0) ? 0.0f : awtGlyphVector.getGlyphMetrics(i - 1).getAdvanceX();
+            float ay = (i == 0) ? 0.0f : awtGlyphVector.getGlyphMetrics(i - 1).getAdvanceY();
+            System.out.printf("%f %f %f ", dx, ax, dx-ax);
+            System.out.printf("%f %f %f\n", dy, ay, dy-ay);
+            System.out.println();
+            lastX = (float) p.getX();
+            lastY = (float) p.getY();
+        }
+    }
+
+
+    public static void testSequencesLine2D(PDPageContentStream cs, PDType0Font font,
+                                          float fontSize, Font awtFont, String line, float x, float y) throws IOException {
+        char[] chars = line.toCharArray();
+        // Use Java2D to compute positioning of glyphs
+        FontRenderContext fontRenderContext = new FontRenderContext(new AffineTransform(), false, true);
+        java.awt.font.GlyphVector glyphVector = awtFont.layoutGlyphVector(fontRenderContext, chars, 0, chars.length,
+                Font.LAYOUT_LEFT_TO_RIGHT);
+        printAdjustmentsAdvancedLayout(line, glyphVector);
+
+        cs.beginText();
+        cs.setFont(font, fontSize);
+        cs.newLineAtOffset(x, y);
+
+        float lastX = 0f;
+        float lastY = 0f;
+        for (int i = 0; i < line.length(); i++) {
+            Point2D p = glyphVector.getGlyphPosition(i);
+
+            float dx = (float) p.getX() - lastX;
+            float dy = (float) p.getY() - lastY;
+
+            cs.newLineAtOffset(dx, -dy);
+            String text = line.substring(i, i + 1);
+
+            cs.showText(text);
+
+            lastX = (float) p.getX();
+            lastY = (float) p.getY();
+        }
+        cs.endText();
+    }
+
+    private static Matrix createMatrix(float translateX, float translateY) {
+        return Matrix.getTranslateInstance(translateX, translateY);
+    }
+
+    public static void printAdjustmentsAdvancedLayout(String line, GlyphVector vector) {
+        GlyphVectorAdvanced vec = (GlyphVectorAdvanced) vector;
+        int[] gids = vec.getGlyphArray();
+        int[][] adjustments = vec.getAdjustments();
+        System.out.println("--Advanced--");
+        System.out.println(line);
+        for (int i=0; i<gids.length; i++) {
+            System.out.printf("%d %d ", i, gids[i]);
+            for (int j=0; j<adjustments[i].length; j++) {
+                System.out.printf("%d ", adjustments[i][j]);
+            }
+            System.out.println();
+        }
+    }
+
+    public static void testAdvancedLayout(String dir, String fontFileName, String s) throws IOException
+    {
+        try (PDDocument document = new PDDocument())
+        {
+            PDPage page = new PDPage(PDRectangle.A4);
+            document.addPage(page);
+
+            String fontFile = dir + "/" + fontFileName;
+
+            OTFParser fontParser = new OTFParser(true, false, true);
+            OpenTypeFont otFont = fontParser.parse(fontFile);
+            PDFont font = PDType0Font.load(document, otFont, true);
+
+            GlyphVector vector;
+            float x = 10;
+
+            try (PDPageContentStream stream = new PDPageContentStream(document, page))
+            {
+                float fontSize = 20;
+                stream.beginText();
+                stream.setFont(font, fontSize);
+
+                s = s.replaceAll("[ \t]", " ");
+                String[] lines = s.split("\n");
+
+                for (String line : lines) {
+                    if (line.length() > 0) {
+                        vector = otFont.createGlyphVector(line);
+                        printAdjustmentsAdvancedLayout(line, vector);
+                        stream.showGlyphVector(vector, createMatrix(x, 200));
+                    }
+                }
+                stream.endText();
+            }
+            document.save("TestDin91379AdvancedLayout.pdf");
+            document.close();
+        }
+    }
+}

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/AdvancedTypographicTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/AdvancedTypographicTable.java
@@ -61,7 +61,7 @@ public class AdvancedTypographicTable extends TTFTable {
     public static final int GLYPH_TABLE_TYPE_DEFINITION = 5;
 
     // (optional) glyph definition table in table types other than glyph definition table
-    protected AdvancedTypographicTable gdef;
+    private AdvancedTypographicTable gdef;
 
     // map from lookup specs to lists of strings, each of which identifies a lookup table (consisting of one or more subtables)
     private Map<LookupSpec, List<String>> lookups;
@@ -105,6 +105,15 @@ public class AdvancedTypographicTable extends TTFTable {
     public GlyphDefinitionTable getGlyphDefinitions() {
         return (GlyphDefinitionTable) gdef;
     }
+
+    /**
+     * Set glyph definition table
+     * @param gdef
+     */
+    public void setGdef(GlyphDefinitionTable gdef) {
+        this.gdef = gdef;
+    }
+
 
     /**
      * Obtain list of all lookup specifications.

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/AdvancedTypographicTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/AdvancedTypographicTable.java
@@ -61,7 +61,7 @@ public class AdvancedTypographicTable extends TTFTable {
     public static final int GLYPH_TABLE_TYPE_DEFINITION = 5;
 
     // (optional) glyph definition table in table types other than glyph definition table
-    private AdvancedTypographicTable gdef;
+    protected AdvancedTypographicTable gdef;
 
     // map from lookup specs to lists of strings, each of which identifies a lookup table (consisting of one or more subtables)
     private Map<LookupSpec, List<String>> lookups;

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphClassTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphClassTable.java
@@ -20,6 +20,9 @@ package org.apache.fontbox.ttf.advanced;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 
 import org.apache.fontbox.ttf.advanced.SubtableEntryHolder.SEGlyphCoverageTable;
 import org.apache.fontbox.ttf.advanced.SubtableEntryHolder.SEInteger;
@@ -258,8 +261,11 @@ public final class GlyphClassTable extends GlyphMappingTable implements GlyphCla
     }
 
     private static class CoverageSetClassTable extends GlyphMappingTable.EmptyMappingTable implements GlyphClassMapping {
+        private static final Log LOG = LogFactory.getLog(CoverageSetClassTable.class);
         public CoverageSetClassTable(List<SubtableEntry> entries) {
-            throw new UnsupportedOperationException("coverage set class table not yet supported");
+            // See FOP-2704
+            // throw new UnsupportedOperationException("coverage set class table not yet supported");
+            LOG.warn("coverage set class table not yet supported");
         }
 
         /** {@inheritDoc} */

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphPositioningTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphPositioningTable.java
@@ -84,7 +84,7 @@ public class GlyphPositioningTable extends AdvancedTypographicTable {
      * @param subtables a list of identified subtables
      */
     public GlyphPositioningTable initialize(GlyphDefinitionTable gdef, Map<LookupSpec, List<String>> lookups, List<GlyphSubtable> subtables) {
-        this.gdef = gdef;
+        setGdef(gdef);
         initialize(lookups);
         if ((subtables == null) || (subtables.size() == 0)) {
             throw new AdvancedTypographicTableFormatException("subtables must be non-empty");

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphPositioningTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphPositioningTable.java
@@ -84,6 +84,7 @@ public class GlyphPositioningTable extends AdvancedTypographicTable {
      * @param subtables a list of identified subtables
      */
     public GlyphPositioningTable initialize(GlyphDefinitionTable gdef, Map<LookupSpec, List<String>> lookups, List<GlyphSubtable> subtables) {
+        this.gdef = gdef;
         initialize(lookups);
         if ((subtables == null) || (subtables.size() == 0)) {
             throw new AdvancedTypographicTableFormatException("subtables must be non-empty");

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphPositioningTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphPositioningTable.java
@@ -249,7 +249,7 @@ public class GlyphPositioningTable extends AdvancedTypographicTable {
      * @param language a language identifier
      * @param fontSize size in device units
      * @param widths array of default advancements for each glyph
-     * @param adjustments accumulated adjustments array (sequence) of 4-tuples of placement [PX,PY] ansd advance [AX,AY] adjustments, in that order,
+     * @param adjustments accumulated adjustments array (sequence) of 4-tuples of placement [PX,PY] and advance [AX,AY] adjustments, in that order,
      * with one 4-tuple for each element of glyph sequence
      * @return true if some adjustment is not zero; otherwise, false
      */

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphPositioningTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphPositioningTable.java
@@ -249,7 +249,7 @@ public class GlyphPositioningTable extends AdvancedTypographicTable {
      * @param language a language identifier
      * @param fontSize size in device units
      * @param widths array of default advancements for each glyph
-     * @param adjustments accumulated adjustments array (sequence) of 4-tuples of placement [PX,PY] and advance [AX,AY] adjustments, in that order,
+     * @param adjustments accumulated adjustments array (sequence) of 4-tuples of placement [PX,PY] ansd advance [AX,AY] adjustments, in that order,
      * with one 4-tuple for each element of glyph sequence
      * @return true if some adjustment is not zero; otherwise, false
      */

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphSubstitutionTable.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/GlyphSubstitutionTable.java
@@ -1176,20 +1176,21 @@ public class GlyphSubstitutionTable extends AdvancedTypographicTable {
             assert (rv != null) && (rv.length > 0);
             assert rsa != null;
             if (rsa.length > 0) {
-                RuleSet rs = rsa [ 0 ];
-                if (rs != null) {
-                    Rule[] ra = rs.getRules();
-                    for (int i = 0, n = ra.length; i < n; i++) {
-                        Rule r = ra [ i ];
-                        if ((r != null) && (r instanceof ChainedClassSequenceRule)) {
-                            ChainedClassSequenceRule cr = (ChainedClassSequenceRule) r;
-                            int[] ica = cr.getClasses(icdt.getClassIndex(gi, ss.getClassMatchSet(gi)));
-                            if (matches(ss, icdt, ica, 0, rv)) {
-                                int[] bca = cr.getBacktrackClasses();
-                                if (matches(ss, bcdt, bca, -1, null)) {
-                                    int[] lca = cr.getLookaheadClasses();
-                                    if (matches(ss, lcdt, lca, rv[0], null)) {
-                                        return r.getLookups();
+                for (RuleSet rs : rsa) {
+                    if (rs != null) {
+                        Rule[] ra = rs.getRules();
+                        for (int i = 0, n = ra.length; i < n; i++) {
+                            Rule r = ra[i];
+                            if ((r != null) && (r instanceof ChainedClassSequenceRule)) {
+                                ChainedClassSequenceRule cr = (ChainedClassSequenceRule) r;
+                                int[] ica = cr.getClasses(icdt.getClassIndex(gi, ss.getClassMatchSet(gi)));
+                                if (matches(ss, icdt, ica, 0, rv)) {
+                                    int[] bca = cr.getBacktrackClasses();
+                                    if (matches(ss, bcdt, bca, -1, null)) {
+                                        int[] lca = cr.getLookaheadClasses();
+                                        if (matches(ss, lcdt, lca, rv[0], null)) {
+                                            return r.getLookups();
+                                        }
                                     }
                                 }
                             }

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
@@ -101,12 +101,10 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
         org.apache.fontbox.ttf.advanced.GlyphPositioningTable positioningTable =
           (org.apache.fontbox.ttf.advanced.GlyphPositioningTable) getGPOS();
 
-        // org.apache.fontbox.ttf.advanced.GlyphDefinitionTable gdefTable =
-        //   (org.apache.fontbox.ttf.advanced.GlyphDefinitionTable) getGDEF();
+        org.apache.fontbox.ttf.advanced.GlyphDefinitionTable gdefTable =
+           (org.apache.fontbox.ttf.advanced.GlyphDefinitionTable) getGDEF();
 
-        // if (gdefTable != null) {
-        //     sequence = gdefTable.reorderCombiningMarks(sequence, widths, gpa, script, language, features);
-        // }
+
 
         Object[][] extraFeatures = new Object[][] {
             //new Object[] { "smcp", Boolean.FALSE },
@@ -115,8 +113,12 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
         //extraFeatures = null;
 
         // TODO: Correct script and language
-        GlyphSequence substituted = substitutionTable != null ? 
-             substitutionTable.substitute(sequence, "latn", "dflt", extraFeatures) : sequence;
+        Object[][] features = {{ "kern", true}, {"mark", true}, {"mkmk", true}};
+        String script = "latn";
+        String language = "dflt";
+
+        GlyphSequence substituted = substitutionTable != null ?
+             substitutionTable.substitute(sequence, script, language, extraFeatures) : sequence;
 
         int[][] adjustments = null;
         int[] widths = null;
@@ -134,30 +136,31 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
 
             // TODO: Correct script, language and font size
             // TODO: widths?
-            Object[][] features = {{ "kern", true}, {"mark", true}, {"mkmk", true}};
             positioned = positioningTable != null ? positioningTable.position(
-                substituted, "latn", "dflt", features, fontSize, widths, adjustments) : false;
+                substituted, script, language, features, fontSize, widths, adjustments) : false;
+        }
 
-            // For positioning an array dx, dy, advance_x, advance_y is needed
-            // Compare output of HarfBuzz hb-shape
+        System.out.printf("createGlyphVector1 i  dx dy dax day w -- positioned %n");
+        for (int i = 0; i < substituted.getGlyphCount(); i++) {
+            System.out.printf("createGlyphVector1 %d %h %d %d %d %d %n", i, substituted.getGlyph(i), adjustments[i][0], adjustments[i][1], adjustments[i][2], adjustments[i][3], widths[i]);
+        }
 
-            System.out.printf("createGlyphVector1 i  cpos px py ax ay w%n");
-            int lastAdjustedWidth = 0;
-            for (int i = 0; i < size; i++) {
-                System.out.printf("createGlyphVector1 %d %d %d %d %d %d %d%n", i, lastAdjustedWidth, adjustments[i][0], adjustments[i][1], adjustments[i][2], adjustments[i][3], widths[i]);
-                if (adjustments[i][0]!=0) {
-                    adjustments[i][0] -= lastAdjustedWidth;
-                }
-                adjustments[i][2] += widths[i]; /* add default advance */
-                lastAdjustedWidth = adjustments[i][2];
-                System.out.printf("createGlyphVector2 %d %d %d %d %d %d %d%n", i, lastAdjustedWidth, adjustments[i][0], adjustments[i][1], adjustments[i][2], adjustments[i][3], widths[i]);
-            }
+
+        GlyphSequence reordered = gdefTable != null ?
+                gdefTable.reorderCombiningMarks(substituted, widths, adjustments, script, language, features) : substituted;
+
+        // For positioning an array dx, dy, advance_x, advance_y is needed
+        // Compare output of HarfBuzz hb-shape
+
+        System.out.printf("createGlyphVector1 2  dx dy dax day w  -- reordered %n");
+        for (int i = 0; i < reordered.getGlyphCount(); i++) {
+            System.out.printf("createGlyphVector2 %d %h %d %d %d %d %n", i, reordered.getGlyph(i), adjustments[i][0], adjustments[i][1], adjustments[i][2], adjustments[i][3], widths[i]);
         }
 
 //System.out.println("widths = " + Arrays.toString(widths));
-        int[] outGlyphs = substituted.getGlyphArray(false);
+        int[] outGlyphs = reordered.getGlyphArray(false);
 //System.out.println("outGlyphs = " + Arrays.toString(outGlyphs));
-        int outSize = substituted.getGlyphCount();
+        int outSize = reordered.getGlyphCount();
 
         float width = 0f;
         for (int i = 0; i < outSize; i++) {
@@ -177,17 +180,14 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
                 }
             }
 
-
 //System.out.println("advance = " + getAdvanceWidth(outGlyphs[i]));
 
             // TODO: Something with yAdjust
             // TODO: Debug width
-
             width += getAdvanceWidth(outGlyphs[i]) + xAdjust;
         }
 
         //System.out.println("w = " + width);
-
         return new GlyphVectorAdvanced(outGlyphs, getNormalizedWidth(width), positioned ? adjustments : null);
     }
 

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
@@ -135,8 +135,9 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
 
             // TODO: Correct script, language and font size
             // TODO: widths?
+            Object[][] features = {{ "kern", true}, {"mark", true}, {"mkmk", true}};
             positioned = positioningTable != null ? positioningTable.position(
-                substituted, "latn", "dflt", null, fontSize, widths, adjustments) : false;
+                substituted, "latn", "dflt", features, fontSize, widths, adjustments) : false;
 
             // For positioning an array dx, dy, advance_x, advance_y is needed
             // Compare output of HarfBuzz hb-shape

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
@@ -72,7 +72,7 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
     /**
      * TODO
      */
-    public GlyphVector createGlyphVector(String text) throws IOException 
+    public GlyphVector createGlyphVector(String text,  int fontSize) throws IOException
     {
         if (text.isEmpty()) {
             return new GlyphVectorSimple(null);
@@ -130,12 +130,25 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
 
             for (int i = 0; i < size; i++) {
                 widths[i] = getAdvanceWidth(workingGlyphs[i]);
+                adjustments[i][2] = widths[i]; /* initialize with default advance */
             }
 
             // TODO: Correct script, language and font size
             // TODO: widths?
             positioned = positioningTable != null ? positioningTable.position(
-                substituted, "latn", "dflt", null, 20, widths, adjustments) : false;
+                substituted, "latn", "dflt", null, fontSize, widths, adjustments) : false;
+
+            // For positioning an array dx, dy, advance_x, advance_y is needed
+            // Compare output of HarfBuzz hb-shape
+            System.out.printf("createGlyphVector1 i  px py ax ay w%n");
+            System.out.printf("createGlyphVector1 %d %d %d %d %d %d%n", 0, adjustments[0][0], adjustments[0][1], adjustments[0][2], adjustments[0][3], widths[0]);
+            for (int i=1; i < size; i++) {
+                System.out.printf("createGlyphVector1 %d %d %d %d %d %d%n", i, adjustments[i][0], adjustments[i][1], adjustments[i][2], adjustments[i][3], widths[i]);
+                if (adjustments[i][0]!=0 && widths[i-1]!=0) {
+                    adjustments[i][0] -= widths[i-1];
+                }
+                System.out.printf("createGlyphVector2 %d %d %d %d %d %d%n", i, adjustments[i][0], adjustments[i][1], adjustments[i][2], adjustments[i][3], widths[i]);
+            }
         }
 
 //System.out.println("widths = " + Arrays.toString(widths));

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
@@ -137,7 +137,7 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
             // TODO: Correct script, language and font size
             // TODO: widths?
             positioned = positioningTable != null ? positioningTable.position(
-                substituted, script, language, features, fontSize, widths, adjustments) : false;
+                substituted, script, language, features, fontSize*1000, getAdvanceWidths(), adjustments) : false;
         }
 
         System.out.printf("createGlyphVector1 i  dx dy dax day w -- positioned %n");

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
@@ -55,6 +55,7 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
     @Override
     public org.apache.fontbox.ttf.GlyphSubstitutionTable getGsub() throws IOException {
         return null;
+        //TODO return (org.apache.fontbox.ttf.advanced.GlyphSubstitutionTable) getTable(org.apache.fontbox.ttf.advanced.GlyphSubstitutionTable.TAG);
     }
 
     /**

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/api/AdvancedOpenTypeFont.java
@@ -130,7 +130,6 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
 
             for (int i = 0; i < size; i++) {
                 widths[i] = getAdvanceWidth(workingGlyphs[i]);
-                adjustments[i][2] = widths[i]; /* initialize with default advance */
             }
 
             // TODO: Correct script, language and font size
@@ -141,14 +140,17 @@ public class AdvancedOpenTypeFont extends OpenTypeFont {
 
             // For positioning an array dx, dy, advance_x, advance_y is needed
             // Compare output of HarfBuzz hb-shape
-            System.out.printf("createGlyphVector1 i  px py ax ay w%n");
-            System.out.printf("createGlyphVector1 %d %d %d %d %d %d%n", 0, adjustments[0][0], adjustments[0][1], adjustments[0][2], adjustments[0][3], widths[0]);
-            for (int i=1; i < size; i++) {
-                System.out.printf("createGlyphVector1 %d %d %d %d %d %d%n", i, adjustments[i][0], adjustments[i][1], adjustments[i][2], adjustments[i][3], widths[i]);
-                if (adjustments[i][0]!=0 && widths[i-1]!=0) {
-                    adjustments[i][0] -= widths[i-1];
+
+            System.out.printf("createGlyphVector1 i  cpos px py ax ay w%n");
+            int lastAdjustedWidth = 0;
+            for (int i = 0; i < size; i++) {
+                System.out.printf("createGlyphVector1 %d %d %d %d %d %d %d%n", i, lastAdjustedWidth, adjustments[i][0], adjustments[i][1], adjustments[i][2], adjustments[i][3], widths[i]);
+                if (adjustments[i][0]!=0) {
+                    adjustments[i][0] -= lastAdjustedWidth;
                 }
-                System.out.printf("createGlyphVector2 %d %d %d %d %d %d%n", i, adjustments[i][0], adjustments[i][1], adjustments[i][2], adjustments[i][3], widths[i]);
+                adjustments[i][2] += widths[i]; /* add default advance */
+                lastAdjustedWidth = adjustments[i][2];
+                System.out.printf("createGlyphVector2 %d %d %d %d %d %d %d%n", i, lastAdjustedWidth, adjustments[i][0], adjustments[i][1], adjustments[i][2], adjustments[i][3], widths[i]);
             }
         }
 

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/scripts/DefaultScriptProcessor.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/scripts/DefaultScriptProcessor.java
@@ -138,7 +138,8 @@ public class DefaultScriptProcessor extends ScriptProcessor {
         for (int i = 0; i < ng; i++) {
             int gid = ga [ i ];
             int gw = unscaledWidths [ i ];
-            if (isReorderedMark(gdef, ga, gpa, i)) {
+            int[] pa = (gpa != null) ? gpa[i] : null;
+            if (isReorderedMark(gdef, ga, unscaledWidths, i, pa)) {
                 nm++;
             }
         }
@@ -152,56 +153,55 @@ public class DefaultScriptProcessor extends ScriptProcessor {
             CharAssociation ba = null;
             int bg = -1;
             int[] bpa = null;
+            int[] order = new int[ng];
             for (int i = 0; i < ng; i++) {
-                int gid = ga [ i ];
-                int[] pa = (gpa != null) ? gpa [ i ] : null;
-                CharAssociation ca = aa [ i ];
-                if (isReorderedMark(gdef, ga, gpa, i)) {
-                    nga [ k ] = gid;
-                    naa [ k ] = ca;
-                    if (npa != null) {
-                        npa [ k ] = pa;
-                    }
-                    k++;
-                } else {
-                    if (bg != -1) {
-                        nga [ k ] = bg;
-                        naa [ k ] = ba;
-                        if (npa != null) {
-                            npa [ k ] = bpa;
+                order[i] = i;
+            }
+            for (int i = 1; i < ng; i++) {
+                int[] pa = (gpa != null) ? gpa[i] : null;
+                if (isReorderedMark(gdef, ga, unscaledWidths, i, pa)) {
+                    for (int j = i; j > 0; j--) {
+                        switchGlyphs(order, j);
+                        int[] paj = (gpa != null) ? gpa[order[j]] : null;
+                        if (!isMarkNotReordered(gdef, ga, unscaledWidths, order[j], paj)) {
+                            System.out.printf("break j=%d%n", j);
+                            break;
                         }
-                        k++;
-                        bg = -1;
-                        ba = null;
-                        bpa = null;
-                    }
-                    if (bg == -1) {
-                        bg = gid;
-                        ba = ca;
-                        bpa = pa;
                     }
                 }
             }
-            if (bg != -1) {
-                nga [ k ] = bg;
-                naa [ k ] = ba;
-                if (npa != null) {
-                    npa [ k ] = bpa;
+            for (int i = 0; i < ng; i++){
+                nga[i] = ga[order[i]];
+                naa[i] = aa[order[i]];
+                if (gpa!=null) {
+                    npa[i] = gpa[order[i]];
                 }
-                k++;
             }
-            assert k == ng;
             if (npa != null) {
                 System.arraycopy(npa, 0, gpa, 0, ng);
             }
-            return new GlyphSequence(gs, null, nga, null, null, naa, null);
+            return  new GlyphSequence(gs, null, nga, null, null, naa, null);
         } else {
             return gs;
         }
     }
 
-    protected boolean isReorderedMark(GlyphDefinitionTable gdef, int[] glyphs, int[][] gpa, int index) {
-        return gdef.isGlyphClass(glyphs[index], GlyphDefinitionTable.GLYPH_CLASS_MARK) && gpa[index][0]!=0;
+    private static void switchGlyphs(int[] order, int i) {
+        if (i<1) {
+            throw new IllegalArgumentException(String.format("%d must be >0", i));
+        }
+        int oi = order[i];
+        order[i] = order[i-1];
+        order[i-1] = oi;
+    }
+
+    protected boolean isReorderedMark(GlyphDefinitionTable gdef, int[] glyphs, int[] unscaledWidths, int index, int[] pa) {
+        pa = (pa != null) ? pa : new int[1];
+        return gdef.isGlyphClass(glyphs[index], GlyphDefinitionTable.GLYPH_CLASS_MARK) && pa[0] != 0;
+    }
+    protected boolean isMarkNotReordered(GlyphDefinitionTable gdef, int[] glyphs, int[] unscaledWidths, int index, int[] pa) {
+        pa = (pa != null) ? pa : new int[1];
+        return gdef.isGlyphClass(glyphs[index], GlyphDefinitionTable.GLYPH_CLASS_MARK) && pa[0] == 0;
     }
 
 }

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/scripts/DefaultScriptProcessor.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/scripts/DefaultScriptProcessor.java
@@ -138,7 +138,7 @@ public class DefaultScriptProcessor extends ScriptProcessor {
         for (int i = 0; i < ng; i++) {
             int gid = ga [ i ];
             int gw = unscaledWidths [ i ];
-            if (isReorderedMark(gdef, ga, unscaledWidths, i)) {
+            if (isReorderedMark(gdef, ga, gpa, i)) {
                 nm++;
             }
         }
@@ -156,7 +156,7 @@ public class DefaultScriptProcessor extends ScriptProcessor {
                 int gid = ga [ i ];
                 int[] pa = (gpa != null) ? gpa [ i ] : null;
                 CharAssociation ca = aa [ i ];
-                if (isReorderedMark(gdef, ga, unscaledWidths, i)) {
+                if (isReorderedMark(gdef, ga, gpa, i)) {
                     nga [ k ] = gid;
                     naa [ k ] = ca;
                     if (npa != null) {
@@ -200,8 +200,8 @@ public class DefaultScriptProcessor extends ScriptProcessor {
         }
     }
 
-    protected boolean isReorderedMark(GlyphDefinitionTable gdef, int[] glyphs, int[] unscaledWidths, int index) {
-        return gdef.isGlyphClass(glyphs[index], GlyphDefinitionTable.GLYPH_CLASS_MARK);
+    protected boolean isReorderedMark(GlyphDefinitionTable gdef, int[] glyphs, int[][] gpa, int index) {
+        return gdef.isGlyphClass(glyphs[index], GlyphDefinitionTable.GLYPH_CLASS_MARK) && gpa[index][0]!=0;
     }
 
 }

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/scripts/DefaultScriptProcessor.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/scripts/DefaultScriptProcessor.java
@@ -201,7 +201,7 @@ public class DefaultScriptProcessor extends ScriptProcessor {
     }
 
     protected boolean isReorderedMark(GlyphDefinitionTable gdef, int[] glyphs, int[] unscaledWidths, int index) {
-        return gdef.isGlyphClass(glyphs[index], GlyphDefinitionTable.GLYPH_CLASS_MARK) && (unscaledWidths[index] == 0);
+        return gdef.isGlyphClass(glyphs[index], GlyphDefinitionTable.GLYPH_CLASS_MARK);
     }
 
 }

--- a/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/scripts/DefaultScriptProcessor.java
+++ b/fontbox/src/main/java/org/apache/fontbox/ttf/advanced/scripts/DefaultScriptProcessor.java
@@ -201,7 +201,7 @@ public class DefaultScriptProcessor extends ScriptProcessor {
     }
 
     protected boolean isReorderedMark(GlyphDefinitionTable gdef, int[] glyphs, int[] unscaledWidths, int index) {
-        return gdef.isGlyphClass(glyphs[index], GlyphDefinitionTable.GLYPH_CLASS_MARK) && (unscaledWidths[index] != 0);
+        return gdef.isGlyphClass(glyphs[index], GlyphDefinitionTable.GLYPH_CLASS_MARK) && (unscaledWidths[index] == 0);
     }
 
 }

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
@@ -368,8 +368,8 @@ abstract class PDAbstractContentStream implements Closeable
                 System.out.printf("TJ pX=%d%n", placementX);
                 writeOperand(-placementX);
                 COSWriter.writeString(font.encodeGlyphId(gids[i]), outputStream);
-                if (placementX != 0) { // update current PDF-position
-                    writeOperand(placementX);
+                if (placementX+advanceX != 0) { // update current PDF-position
+                    writeOperand(placementX+advanceX);
                     COSWriter.writeString(EMPTY_COS_STRING, outputStream);
                 }
                 write("] ");

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
@@ -98,6 +98,8 @@ abstract class PDAbstractContentStream implements Closeable
     private final Map<PDType0Font, GsubWorker> gsubWorkers = new HashMap<>();
     private final GsubWorkerFactory gsubWorkerFactory = new GsubWorkerFactory();
 
+    private final COSString EMPTY_COS_STRING = new COSString("");
+
     /**
      * Create a new appearance stream.
      *
@@ -354,7 +356,7 @@ abstract class PDAbstractContentStream implements Closeable
                     advanceX = adjustments[i][2];
                     // not used: advanceY = adjustments[i][3];;
                 }
-                if (placementY!=0) {
+                if (placementY != 0) {
                     System.out.printf("placementY=%d rise=%f%n", placementY, placementY*fontSize/1000.0f);
                     setTextRise(placementY*fontSize/1000.0f);
                 }
@@ -362,6 +364,10 @@ abstract class PDAbstractContentStream implements Closeable
                 System.out.printf("TJ pX=%d%n", placementX);
                 writeOperand(-placementX);
                 COSWriter.writeString(font.encodeGlyphId(gids[i]), outputStream);
+                if (placementX != 0) { // update current PDF-position
+                    writeOperand(placementX);
+                    COSWriter.writeString(EMPTY_COS_STRING, outputStream);
+                }
                 write("] ");
                 writeOperator(OperatorName.SHOW_TEXT_ADJUSTED);
                 if (placementY!=0) {

--- a/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
+++ b/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/PDAbstractContentStream.java
@@ -46,7 +46,11 @@ import org.apache.fontbox.ttf.gsub.GsubWorker;
 import org.apache.fontbox.ttf.gsub.GsubWorkerFactory;
 import org.apache.fontbox.ttf.model.GsubData;
 import org.apache.pdfbox.contentstream.operator.OperatorName;
-import org.apache.pdfbox.cos.*;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSNumber;
+import org.apache.pdfbox.cos.COSString;
 import org.apache.pdfbox.pdfwriter.COSWriter;
 import org.apache.pdfbox.pdmodel.documentinterchange.markedcontent.PDPropertyList;
 import org.apache.pdfbox.pdmodel.font.PDFont;
@@ -1720,13 +1724,10 @@ abstract class PDAbstractContentStream implements Closeable
     {
         double[] values = new double[6];
         transform.getMatrix(values);
-        System.out.printf("writeAffineTransform(");
         for (double v : values)
         {
-            System.out.printf("%f ", (float)v);
             writeOperand((float) v);
         }
-        System.out.println();
     }
 
     /**


### PR DESCRIPTION
I added and changed some classes for a proof of concept, that glyph positoning 
with Noto Sans Regular and the combined characters of DIN SPEC 91379 works correctly.
The test program AdvancedTextLayoutSequencesDin91379 produces:
[TestDin91379AdvancedLayout-NotoSans-Regular.ttf-20.0.pdf](https://github.com/danfickle/pdfbox/files/8834643/TestDin91379AdvancedLayout-NotoSans-Regular.ttf-20.0.pdf)

